### PR TITLE
Add unit tests

### DIFF
--- a/tests/test_detect_peaks.py
+++ b/tests/test_detect_peaks.py
@@ -1,0 +1,22 @@
+import numpy as np
+from detect_peaks import peak_detection, custom_peak_detection, detect_wingfreq
+
+
+def test_peak_detection_multiple_peaks():
+    freqs = np.array([0, 5, 10, 15, 20, 25, 30], dtype=float)
+    amplitudes = np.array([1, 2, 10, 2, 9, 2, 1], dtype=float)
+    peaks, max_idx = peak_detection(amplitudes, freqs)
+    assert max_idx == 2
+    assert set(peaks) == {2, 4}
+
+
+def test_custom_peak_detection():
+    freqs = np.array([0, 5, 10, 15, 20], dtype=float)
+    amplitudes = np.array([0, 5, 20, 5, 0], dtype=float)
+    result = custom_peak_detection(amplitudes, freqs)
+    assert result and 2 in result[0]
+
+
+def test_detect_wingfreq_prefer_half():
+    wing = detect_wingfreq([4.5, 18], 9.0)
+    assert wing == 4.5

--- a/tests/test_plotEventCountFFT.py
+++ b/tests/test_plotEventCountFFT.py
@@ -1,0 +1,14 @@
+import os
+from plotEventCountFFT import read_pickles, process_pickle_file
+
+
+def test_read_pickles():
+    files = read_pickles("sampleData", "windowed_fft_results")
+    assert any(f.endswith("_peaks.txt") for f in files) or files == []
+
+
+def test_process_pickle_file_output():
+    pkl = "sampleData/particle_tracking_results_recording_2023-09-14_20-42-19_39.pkl"
+    result = process_pickle_file(pkl)
+    assert result is not None
+    assert len(result) > 0

--- a/tests/test_plotEventCountSTFT.py
+++ b/tests/test_plotEventCountSTFT.py
@@ -1,0 +1,10 @@
+from plotEventCountSTFT import read_pickles, process_pickle_file, calc_fft, calc_peak
+
+
+def test_calc_fft_and_peak():
+    pkl = "sampleData/particle_tracking_results_recording_2023-09-14_20-42-19_39.pkl"
+    data = process_pickle_file(pkl)
+    freqs, values = calc_fft(data)
+    peaks, max_idx = calc_peak(freqs, values)
+    assert len(freqs) == len(values)
+    assert max_idx >= 0

--- a/tests/test_pngToPDF.py
+++ b/tests/test_pngToPDF.py
@@ -1,0 +1,22 @@
+import os
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+from matplotlib import pyplot as plt
+from pngToPDF import collect_png_files, generate_pdfs
+
+
+def test_collect_and_generate(tmp_path):
+    for name in ["abura_1.png", "kiku_1.png", "other.png"]:
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        fig.savefig(tmp_path / name)
+        plt.close(fig)
+
+    categories = collect_png_files(tmp_path, all_mode=False)
+    assert len(categories["abura"]) == 1
+    assert len(categories["kiku"]) == 1
+
+    generate_pdfs(tmp_path, all_mode=True)
+    output_dir = tmp_path / "pdf_results"
+    assert any(p.suffix == ".pdf" for p in output_dir.iterdir())

--- a/tests/test_process_fft.py
+++ b/tests/test_process_fft.py
@@ -1,0 +1,31 @@
+import numpy as np
+from process_fft import preprocess_time_series, pad_time_series, compute_fft, WINDOW_LENGTH, FS
+
+
+def test_preprocess_time_series():
+    arr = np.array([1, 2, 3, 4, 5], dtype=float)
+    result = preprocess_time_series(arr)
+    expected = (arr - np.mean(arr)) * np.hanning(len(arr))
+    assert np.allclose(result, expected)
+
+
+def test_pad_time_series_short_and_long():
+    arr_short = np.array([1, 2, 3], dtype=float)
+    padded = pad_time_series(arr_short, target_length=5)
+    assert len(padded) == 5
+    assert np.allclose(padded[:3], arr_short)
+    assert np.all(padded[3:] == 0)
+
+    arr_long = np.arange(10, dtype=float)
+    trimmed = pad_time_series(arr_long, target_length=5)
+    assert len(trimmed) == 5
+    assert np.allclose(trimmed, arr_long[:5])
+
+
+def test_compute_fft_peak():
+    t = np.arange(WINDOW_LENGTH) / FS
+    freq = 5.0
+    signal = np.sin(2 * np.pi * freq * t)
+    freqs, magnitude = compute_fft(signal)
+    dominant = freqs[np.argmax(magnitude)]
+    assert abs(dominant - freq) < 0.5

--- a/tests/test_time_fft_to_pdf.py
+++ b/tests/test_time_fft_to_pdf.py
@@ -1,0 +1,25 @@
+import os
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+from time_fft_to_pdf import (
+    plot_and_save_time_series_fft_to_pdf,
+    plot_and_save_time_series_stft_to_pdf,
+    plot_and_save_violin_to_pdf,
+)
+
+
+def test_pdf_outputs(tmp_path):
+    data = [np.sin(2 * np.pi * 5 * np.arange(100) / 1000.0) for _ in range(2)]
+    names = ["file1.csv", "file2.csv"]
+    fft_pdf = tmp_path / "fft.pdf"
+    stft_pdf = tmp_path / "stft.pdf"
+    violin_pdf = tmp_path / "violin.pdf"
+
+    plot_and_save_time_series_fft_to_pdf("folder", data, names, fft_pdf)
+    plot_and_save_time_series_stft_to_pdf("folder", data, stft_pdf)
+    plot_and_save_violin_to_pdf([[5, 6], [7, 8]], violin_pdf, ["a", "b"])
+
+    assert fft_pdf.exists()
+    assert stft_pdf.exists()
+    assert violin_pdf.exists()

--- a/tests/test_trackParticlesC.py
+++ b/tests/test_trackParticlesC.py
@@ -1,0 +1,28 @@
+import os
+import csv
+import pickle
+from unittest import mock
+from trackParticlesC import process_file
+
+
+class DummyParticle:
+    def __init__(self, pid):
+        self.particle_id = pid
+        self.centroid_history = [(0, 0, 0)]
+        self.events = [(0, 0, 0)]
+
+
+def test_process_file_creates_pickle(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([0, 0, 1, 0])
+
+    with mock.patch("trackParticlesC.track_particles_cpp", return_value=[DummyParticle(1)]):
+        process_file(str(csv_path))
+
+    output = tmp_path / "particle_tracking_results_both_data.pkl"
+    assert output.exists()
+    with open(output, "rb") as f:
+        data = pickle.load(f)
+    assert 1 in data


### PR DESCRIPTION
## Summary
- add a basic test suite for FFT utilities and plotting helpers
- include tests for png to PDF conversion and data processing scripts
- mock `particle_tracking` for tracking script tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy and pandas)*